### PR TITLE
Remove duplicate `vpc_security_group_ids`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,10 +54,6 @@ resource "aws_rds_cluster" "default" {
 
   db_subnet_group_name         = "${aws_db_subnet_group.default.name}"
 
-  vpc_security_group_ids       = [
-    "${aws_security_group.default.id}",
-  ]
-
   tags                         = {
     Name      = "${module.label.id}"
     Namespace = "${var.namespace}"

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_rds_cluster_instance" "default" {
 
 resource "aws_db_subnet_group" "default" {
   name        = "${module.label.id}"
-  description = "Allowed subnets for Aurora DB cluster instances"
+  description = "Allowed subnets for DB cluster instances"
   subnet_ids  = ["${var.subnets}"]
 }
 


### PR DESCRIPTION
## What

* Remove duplicate attribute
* Remove `Aurora` from the description


## Why

* The module could be used to create any DB cluster including regular RDS for MySQL and Postgres, not only Aurora
